### PR TITLE
Fix/ui ux

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -209,5 +209,11 @@ body {
 // タブ部分
 
 .nav-tabs .nav-link.active, .nav-tabs .nav-item.show .nav-link {
-  background-color: #f3f3f6;
+  background-color: #e8f0fe;
+}
+
+// 新着通知の背景色
+
+.new_notification {
+  background-color: #e8f0fe;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -205,3 +205,9 @@ body {
 .rank_text {
   font-size: 30px;
 }
+
+// タブ部分
+
+.nav-tabs .nav-link.active, .nav-tabs .nav-item.show .nav-link {
+  background-color: #f3f3f6;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -244,3 +244,9 @@ body {
 .new_notification {
   background-color: #e8f0fe;
 }
+
+.content_container {
+  margin: auto;
+  width: 350px;
+  text-align: left;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -149,6 +149,33 @@ button {
   @include basic_container()
 }
 
+@mixin large_form($height) {
+  height: $height;
+  width: 400px;
+  margin: 0;
+  padding: 0;
+  background: #fff;
+  border: solid 2px #e8f0fe;
+  border-radius: 5px;
+  outline: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+textarea.large_text_area {
+  @include large_form(200px)
+}
+
+input.large_text_field {
+  @include large_form(50px)
+}
+
+.category_container {
+  margin: auto;
+  width: 400px;
+}
+
 /* Sticky footer styles
 -------------------------------------------------- */
 html {

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,10 +1,17 @@
 class NotificationsController < ApplicationController
   before_action :authenticate_user!
+  after_action :check_notifications
 
   def index
-    @notifications = current_user.passive_notifications.where(checked: false).
+    @notifications = current_user.passive_notifications.
       includes(:visitor, :visited).page(params[:page]).per(10)
-    @notifications.each do |notification|
+  end
+
+  private
+
+  def check_notifications
+    notifications = current_user.passive_notifications.includes(:visitor, :visited)
+    notifications.where(checked: false).each do |notification|
       notification.update_attributes(checked: true)
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -122,7 +122,7 @@ class User < ApplicationRecord
     end
   end
 
-  def has_notifications?
+  def has_new_notifications?
     passive_notifications.where(checked: false).present?
   end
 

--- a/app/views/answers/_index.html.slim
+++ b/app/views/answers/_index.html.slim
@@ -20,8 +20,7 @@
 
     / 回答本文
     hr
-    .mt-5.mb-5
-      p= answer.content
+    = render partial: 'shared/content', locals: { content: answer.content }
 
     / ベストアンサーボタン
     - if current_user == answer.question.user && !answer.question.has_best_answer?

--- a/app/views/answers/_index.html.slim
+++ b/app/views/answers/_index.html.slim
@@ -4,8 +4,10 @@
     p.text-danger.text-center.mb-3
       | #{icon('fas', 'check')}
       | ベストアンサー！
-  / 高評価
-  = render partial: 'likes/form', locals: { likable: answer }
+  .container
+    .row
+      / いいね
+      = render partial: 'likes/form', locals: { likable: answer }
   .text-center
       
     / 回答部分

--- a/app/views/answers/_submit_form.html.slim
+++ b/app/views/answers/_submit_form.html.slim
@@ -4,6 +4,6 @@
       = render 'shared/error_messages', model: f.object
       = f.hidden_field :question_id, value: question.id
       .form-group
-        = f.text_area :content
+        = f.text_area :content, placeholder: '回答を入力(1000文字以内)', class: 'large_text_area'
       .form-group
         = f.submit '回答する', class: 'btn btn-primary'

--- a/app/views/comments/_form.html.slim
+++ b/app/views/comments/_form.html.slim
@@ -2,6 +2,6 @@
   = form_with model: [commentable, comment] do |f|
     = f.hidden_field :user_id, value: current_user.id
     .form-group
-      = f.text_area :content, placeholder: 'コメントを入力', class: "comment_form_#{commentable.id}"
+      = f.text_area :content, placeholder: 'コメントを入力(1000文字以内)', class: "comment_form_#{commentable.id} large_text_area"
     .form-group
       = f.submit 'コメントする', class: 'btn btn-primary'

--- a/app/views/comments/_index.html.slim
+++ b/app/views/comments/_index.html.slim
@@ -12,6 +12,7 @@
           = form_with model: [comment], method: :delete do |f|
             = button_tag type: :submit , class: "delete_comment_#{comment.id} text-primary" do
               = icon('fas', 'trash')
-    p.mt-4 #{comment.content}
+    / 内容表示部分
+    = render partial: 'shared/content', locals: { content: comment.content }
     hr
     

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -27,7 +27,7 @@ nav.navbar.navbar-expand-lg.navbar-light
   - if user_signed_in?
     ul.navbar-nav.mr-auto
       li.nav-item
-        = link_to icon('fas', 'bell'), notifications_path, class: (current_user.has_notifications? ? 'nav-link text-danger' : 'nav-link')
+        = link_to icon('fas', 'bell'), notifications_path, class: (current_user.has_new_notifications? ? 'nav-link text-danger' : 'nav-link')
       li.nav-item.dropdown
         a#navbarDropdown.nav-link.dropdown-toggle aria-expanded="false" aria-haspopup="true" data-toggle="dropdown" href="#" role="button" 
           | #{image_tag(current_user.profile_image.url, size: '30x30', class: 'rounded-circle')}

--- a/app/views/notifications/_notification.html.slim
+++ b/app/views/notifications/_notification.html.slim
@@ -1,27 +1,29 @@
 - visitor = notification.visitor
 - visited = notification.visited
-= link_to "#{visitor.name}さんが", user_path(visitor.id)
-- case notification.action
-- when 'follow' then
-  | あなたをフォローしました
-- when 'answer' then
-  = link_to 'あなたの質問', question_path(notification.answer.question.id)
-  | に回答しました
-- when 'best_answer' then
-  = link_to 'あなたの回答', question_path(notification.answer.question.id)
-  | をベストアンサーに決定しました
-- when 'stock' then
-  = link_to 'あなたの質問', question_path(notification.question.id)
-  | をストックしました
-- when 'comment' then
-  - case notification.comment.commentable_type
-  - when 'Question' then
-    = link_to '質問', question_path(notification.comment.commentable.id)
-    | にコメントしました
-  - when 'Answer' then
-    = link_to '質問の回答', question_path(notification.comment.commentable.id)
-    | にコメントしました
-  - when 'Post' then
-    = link_to '投稿', post_path(notification.comment.commentable.id)
-    | にコメントしました
-hr
+div class=(notification.checked ? '' : 'new_notification')
+  .text-left
+    = link_to image_tag(visitor.profile_image.url, size: '50x50', class: 'rounded-circle') + "#{visitor.name}さんが", user_path(visitor.id)
+    - case notification.action
+    - when 'follow' then
+      | あなたをフォローしました
+    - when 'answer' then
+      = link_to 'あなたの質問', question_path(notification.answer.question.id)
+      | に回答しました
+    - when 'best_answer' then
+      = link_to 'あなたの回答', question_path(notification.answer.question.id)
+      | をベストアンサーに決定しました
+    - when 'stock' then
+      = link_to 'あなたの質問', question_path(notification.question.id)
+      | をストックしました
+    - when 'comment' then
+      - case notification.comment.commentable_type
+      - when 'Question' then
+        = link_to '質問', question_path(notification.comment.commentable.id)
+        | にコメントしました
+      - when 'Answer' then
+        = link_to '質問の回答', question_path(notification.comment.commentable.id)
+        | にコメントしました
+      - when 'Post' then
+        = link_to '投稿', post_path(notification.comment.commentable.id)
+        | にコメントしました
+    hr

--- a/app/views/notifications/index.html.slim
+++ b/app/views/notifications/index.html.slim
@@ -1,6 +1,8 @@
 .notification_container
   - if @notifications.present?
+    - unless current_user.has_new_notifications?
+    h2.text-center.my-4 新着の通知はありません
     = render partial: 'notifications/notification', collection: @notifications, as: :notification
     = paginate @notifications
   - else
-    p  通知はありません
+    h2.text-center.my-4 通知はありません

--- a/app/views/notifications/index.html.slim
+++ b/app/views/notifications/index.html.slim
@@ -1,8 +1,8 @@
 .notification_container
   - if @notifications.present?
     - unless current_user.has_new_notifications?
-    h2.text-center.my-4 新着の通知はありません
+    h2.text-center.py-4 新着の通知はありません
     = render partial: 'notifications/notification', collection: @notifications, as: :notification
     = paginate @notifications
   - else
-    h2.text-center.my-4 通知はありません
+    h2.text-center.py-4 通知はありません

--- a/app/views/posts/_form.html.slim
+++ b/app/views/posts/_form.html.slim
@@ -1,13 +1,15 @@
 - if user_signed_in? && current_user == user
   = form_with model: [current_user, current_user.posts.new] do |f|
     .form-group
-      = f.text_area :content
+      = f.text_area :content, class: 'large_text_area', placeholder: '内容を入力(1000)文字以内'
     .form-group
       = f.label :category, 'カテゴリ'
-      = f.collection_check_boxes(:category_ids, Category.all, :id, :name, include_hidden: false) do |category|
-        = category.label do
-          = category.check_box
-          .badge.badge-secondary
-            = category.text
+      br
+      .category_container
+        = f.collection_check_boxes(:category_ids, Category.all, :id, :name, include_hidden: false) do |category|
+          = category.label do
+            = category.check_box
+            .badge.badge-secondary.mr-1
+              = category.text
     = f.submit '投稿する', class: 'btn btn-primary'
     

--- a/app/views/posts/_post.html.slim
+++ b/app/views/posts/_post.html.slim
@@ -18,13 +18,18 @@ div class="text-center post_#{post.id}"
         = distance_of_time_in_words_to_now(post.created_at)
       .col-1
         = link_to icon('fas', 'arrow-right'), post_path(post.id), class: 'mr-4'
+
+  / 内容表示部分
   hr
-  .mt-3.mb-3
-    p #{post.content}
+  = render partial: 'shared/content', locals: { content: post.content }
   hr
   .row
+
+    / カテゴリー表示部分
     .col-8
       = render partial: 'category/tag', locals: { taggable: post }
+    
+    / コメント、いいね表示部分
     .col-4
       .row
         = icon('far', 'comment')

--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -5,17 +5,19 @@
       .form-group
         = f.label :title
         br
-        = f.text_field :title
+        = f.text_field :title, placeholder: 'タイトルを入力(50文字以内)', class: 'large_text_field'
       .form-group
         = f.label :content
         br
-        = f.text_area :content
+        = f.text_area :content, placeholder: '内容を入力(1000文字以内)', class: 'large_text_area'
       .form-group
         = f.label :category, 'カテゴリ'
-        = f.collection_check_boxes(:category_ids, Category.all, :id, :name, include_hidden: false) do |category|
-          = category.label do
-            = category.check_box
-            .badge.badge-secondary
-              = category.text
+        br
+        .category_container
+          = f.collection_check_boxes(:category_ids, Category.all, :id, :name, include_hidden: false) do |category|
+            = category.label do
+              = category.check_box
+              .badge.badge-secondary.mr-1
+                = category.text
       .form-group
         = f.submit '質問', class: 'btn btn-primary'

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -27,8 +27,7 @@
       br
     hr
     / 本文
-    .mt-5.mb-5
-      p #{@question.content}
+    = render partial: 'shared/content', locals: { content: @question.content }
     /カテゴリー表示
     = render partial: 'category/tag', locals: { taggable: @question }
     br

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -2,17 +2,17 @@
   / タイトル
   .mb-5.text-center
     h1 #{@question.title}
-  .row
-    .col-6
-      / 高評価
-      = render partial: 'likes/form', locals: { likable: @question }
-      /ストックボタン
-      = render partial: 'stocks/form', locals: { question: @question }
-    .col-6
-      = distance_of_time_in_words_to_now(@question.created_at)
   .container.text-center
+    br
+    .container
+      .row
+        .row.mr-2
+          = render partial: 'likes/form', locals: { likable: @question }
+        / ストックボタン
+        = render partial: 'stocks/form', locals: { question: @question }
+    hr
     .row
-      .col-6
+      .col-4
         = render partial: 'users/user_image_link', locals: { user: @question.user }
         = link_to @question.user.name, user_path(@question.user.id)
       .col-2
@@ -20,6 +20,8 @@
           p.text-success 解決済み
         - else
           p 未解決
+      .col-2
+        = distance_of_time_in_words_to_now(@question.created_at)
       .col-4
         -if current_user == @question.user
           = link_to icon('fas', 'edit'), edit_question_path(@question.id), class: "edit-q-#{@question.id} mr-4"
@@ -31,6 +33,8 @@
     /カテゴリー表示
     = render partial: 'category/tag', locals: { taggable: @question }
     br
+    /質問のコメント表示
+    = render partial: 'comments/index', locals: { comments: @question.comments }
     / コメント、回答入力フォーム
     - if user_signed_in?
       button data-toggle='collapse' data-target='#collapse_comment' aria-expanded='false' aria-controls='collapse_comment' 
@@ -43,8 +47,6 @@
       .collapse#collapse_answer
         hr
         = render partial: 'answers/submit_form', locals: { question: @question }
-    /質問のコメント表示
-    = render partial: 'comments/index', locals: { comments: @question.comments }
 
 /回答表示
 = render partial: 'answers/index', collection: @answers, as: :answer, locals: { question: @question }

--- a/app/views/rankings/index.html.slim
+++ b/app/views/rankings/index.html.slim
@@ -1,9 +1,9 @@
 / タブのリンク部分
 ul.nav.nav-tabs.justify-content-center
   li.nav-item
-    a.nav-link.text-muted.active data-toggle="tab" href="#answers_ranking" 回答数ランキング
+    a.nav-link.bold_texts.active data-toggle="tab" href="#answers_ranking" 回答数ランキング
   li.nav-item
-    a.nav-link.text-muted data-toggle="tab" href="#questions_ranking" 質問数ランキング
+    a.nav-link.bold_texts data-toggle="tab" href="#questions_ranking" 質問数ランキング
 / タブの表示部分
 .tab-content.text-center
   #answers_ranking.tab-pane.active

--- a/app/views/shared/_content.html.slim
+++ b/app/views/shared/_content.html.slim
@@ -1,0 +1,2 @@
+.my-4.content_container
+  p= simple_format content

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -15,12 +15,15 @@
               = render partial: 'shared/follow_button', locals: { user: @user }
           p 質問数 #{@user.questions.count}
           p 回答数 #{@user.answers.count}
-          .row
-            .col-6
-              = link_to "#{@user.followees.count}フォロー", user_followees_path(@user.id)
-            .col-6
-              = link_to "#{@user.followers.count}フォロワー", user_followers_path(@user.id), class: "followers_count_#{@user.id}"
-          p.font-weight-bold フォロー中のタグ
+          .container.my-2
+            .row
+              .col-6
+                = link_to "#{@user.followees.count}フォロー", user_followees_path(@user.id)
+              .col-6
+                = link_to "#{@user.followers.count}フォロワー", user_followers_path(@user.id), class: "followers_count_#{@user.id}"
+          p.font-weight-bold フォロー中のカテゴリー
+          - if @user.categories.blank?
+            p フォロー中のカテゴリーはありません
           = render partial: 'category/tag', locals: { taggable: @user }
     .col-8
       / タブのリンク部分

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -26,11 +26,11 @@
       / タブのリンク部分
       ul.nav.nav-tabs.justify-content-center
         li.nav-item
-          a.nav-link.text-muted.active data-toggle="tab" href="#user_questions" 質問
+          a.nav-link.bold_texts.active data-toggle="tab" href="#user_questions" 質問
         li.nav-item
-          a.nav-link.text-muted data-toggle="tab" href="#user_answers" 回答した質問
+          a.nav-link.bold_texts data-toggle="tab" href="#user_answers" 回答した質問
         li.nav-item
-          a.nav-link.text-muted data-toggle="tab" href="#user_posts" 投稿
+          a.nav-link.bold_texts data-toggle="tab" href="#user_posts" 投稿
       / タブの表示部分
       .tab-content.text-center
         #user_questions.tab-pane.active

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -166,18 +166,18 @@ RSpec.describe User, type: :model do
       end
     end
 
-    describe 'has_notifications?' do
+    describe 'has_new_notifications?' do
       context '未読の通知がある時' do
         before { user.passive_notifications.create(visitor: other_user, action: 'follow',) }
 
         example 'trueを返すこと' do
-          expect(user.has_notifications?).to eq true
+          expect(user.has_new_notifications?).to eq true
         end
       end
 
       context '未読の通知がない場合' do
         example 'falseを返すこと' do
-          expect(user.has_notifications?).to eq false
+          expect(user.has_new_notifications?).to eq false
         end
       end
     end

--- a/spec/system/notifications_spec.rb
+++ b/spec/system/notifications_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe "Notifications", type: :system do
 
     before { login_as user, scope: :user }
 
-    shared_examples '通知が存在しないこと' do
+    shared_examples '新着通知が存在しないこと' do
       example '通知が作成されていないこと' do
-        expect(page).to have_content '通知はありません'
+        expect(page).to have_content '新着の通知はありません'
       end
     end
 
@@ -33,7 +33,7 @@ RSpec.describe "Notifications", type: :system do
             visit notifications_path
           end
 
-          include_examples '通知が存在しないこと'
+          include_examples '新着通知が存在しないこと'
         end
       end
 
@@ -43,7 +43,7 @@ RSpec.describe "Notifications", type: :system do
           visit notifications_path
         end
 
-        include_examples '通知が存在しないこと'
+        include_examples '新着通知が存在しないこと'
       end
     end
 
@@ -64,7 +64,7 @@ RSpec.describe "Notifications", type: :system do
           visit notifications_path
         end
 
-        include_examples '通知が存在しないこと'
+        include_examples '新着通知が存在しないこと'
       end
     end
 
@@ -88,7 +88,7 @@ RSpec.describe "Notifications", type: :system do
           visit notifications_path
         end
 
-        include_examples '通知が存在しないこと'
+        include_examples '新着通知が存在しないこと'
       end
     end
 
@@ -113,7 +113,7 @@ RSpec.describe "Notifications", type: :system do
           visit notifications_path
         end
 
-        include_examples '通知が存在しないこと'
+        include_examples '新着通知が存在しないこと'
       end
     end
 
@@ -157,7 +157,9 @@ RSpec.describe "Notifications", type: :system do
             visit notifications_path
           end
 
-          include_examples '通知が存在しないこと'
+          example '通知が作成されていないこと' do
+            expect(page).to have_content '通知はありません'
+          end
         end
       end
 
@@ -177,7 +179,7 @@ RSpec.describe "Notifications", type: :system do
         end
       end
 
-      describe 'commentable => answer' do
+      describe 'commentable => post' do
         include_examples 'コメント通知のテスト' do
           let(:first_notification_text) { "#{comment.user.name}さんが投稿にコメントしました" }
           let(:second_notification_text) { "#{other_comment.user.name}さんが投稿にコメントしました" }


### PR DESCRIPTION
#74 #88 

## 変更点

- タブ
  - デザイン修正
- 通知画面
  - 既読の通知は残す。
  - 未読の通知は色を変える
- フォーム画面
  - placeholderやデザイン変更
- カテゴリー選択部分
  - 横一列ではなく縦に配置
- ユーザーページのフォロー中のタグの下に、何もタグをフォローしていない場合はまだカテゴリーをフォローしていません的な文言を加えた
- question, answerのいいね数の表示が縦になってしまっているので、横並びに直した
- テキスト表示部分をスマートにする
`simple_format()` メソッドを使って改行を有効化し、表示部分を整えた