### PR TITLE
Fix/some bugs

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -250,3 +250,9 @@ body {
   width: 350px;
   text-align: left;
 }
+
+// エラーメッセージ部分のスタイリング
+
+.alert > ul {
+  list-style: none;
+}

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -42,7 +42,8 @@ class QuestionsController < ApplicationController
       @question.set_taggable
       redirect_to question_path(@question.id), flash: { success: '質問を編集しました' }
     else
-      redirect_to edit_question_path(@question.id), flash: { danger: '編集に失敗しました' }
+      flash.now[:danger] = '編集に失敗しました'
+      render action: :edit
     end
   end
 

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -11,7 +11,7 @@ class QuestionsController < ApplicationController
     @question = Question.find(params[:id])
     @related_questions = @question.related_questions
     @user = @question.user
-    @answers = @question.answers.all
+    @answers = @question.answers.includes(:user, :likes, :comments)
   end
 
   def new
@@ -24,7 +24,8 @@ class QuestionsController < ApplicationController
     if @question.save
       redirect_to question_path(@question.id), flash: { success: '投稿しました' }
     else
-      redirect_to questions_path, flash: { danger: '投稿に失敗しました' }
+      flash.now[:danger] = '投稿に失敗しました'
+      render action: :new
     end
   end
 

--- a/app/views/answers/_index.html.slim
+++ b/app/views/answers/_index.html.slim
@@ -36,8 +36,8 @@
 
     / コメント入力フォーム
     - if user_signed_in?
-      button data-toggle='collapse' data-target='#collapse_comment' aria-expanded='false' aria-controls='collapse_comment' 
+      button data-toggle='collapse' data-target='#collapse_comment_answer' aria-expanded='false' aria-controls='collapse_comment' 
         p.bold_texts #{icon('far', 'comment')}コメントを投稿
-      .collapse#collapse_comment
+      .collapse#collapse_comment_answer
         hr
         = render partial: 'comments/form', locals: { commentable: answer, comment: current_user.comments.build }

--- a/app/views/answers/_submit_form.html.slim
+++ b/app/views/answers/_submit_form.html.slim
@@ -1,9 +1,8 @@
 - if user_signed_in?
   .text-center
     = form_with model: question.answers.new, url: question_answers_path(question_id: question.id) do |f|
-      = render 'shared/error_messages', model: f.object
       = f.hidden_field :question_id, value: question.id
       .form-group
-        = f.text_area :content, placeholder: '回答を入力(1000文字以内)', class: 'large_text_area'
+        = f.text_area :content, placeholder: '回答を入力(1000文字以内)', class: 'large_text_area', required: true, maxlength: 1000
       .form-group
         = f.submit '回答する', class: 'btn btn-primary'

--- a/app/views/comments/_form.html.slim
+++ b/app/views/comments/_form.html.slim
@@ -2,6 +2,6 @@
   = form_with model: [commentable, comment] do |f|
     = f.hidden_field :user_id, value: current_user.id
     .form-group
-      = f.text_area :content, placeholder: 'コメントを入力(1000文字以内)', class: "comment_form_#{commentable.id} large_text_area"
+      = f.text_area :content, placeholder: 'コメントを入力(1000文字以内)', class: "comment_form_#{commentable.id} large_text_area", required: true, maxlength: 1000
     .form-group
       = f.submit 'コメントする', class: 'btn btn-primary'

--- a/app/views/likes/_form.html.slim
+++ b/app/views/likes/_form.html.slim
@@ -1,5 +1,5 @@
 - if user_signed_in?
-  div class="likable_form_#{likable.id}"
+  div class="likable_form_#{likable.class.name}_#{likable.id}"
     - if likable.liked?(current_user)
       = render partial: 'likes/unlike_form', locals: { likable: likable}
     - else
@@ -7,5 +7,5 @@
 - else
   = icon('fas', 'heart')
 .object_counts
-  div class="likable_count_#{likable.id}"
+  div class="likable_count_#{likable.class.name}_#{likable.id}"
     = likable.likes.count

--- a/app/views/likes/create.js.erb
+++ b/app/views/likes/create.js.erb
@@ -1,2 +1,2 @@
-$(".likable_form_" + "<%= @likable.id %>").html("<%= escape_javascript(render partial: 'likes/unlike_form', locals: { likable: @likable }) %>")
-$(".likable_count_" + "<%= @likable.id %>").html("<%= @likable.likes.count %>")
+$(".likable_form_" + "<%= @likable.class.name %>_<%= @likable.id %>").html("<%= escape_javascript(render partial: 'likes/unlike_form', locals: { likable: @likable }) %>")
+$(".likable_count_" + "<%= @likable.class.name %>_<%= @likable.id %>").html("<%= @likable.likes.count %>")

--- a/app/views/likes/destroy.js.erb
+++ b/app/views/likes/destroy.js.erb
@@ -1,2 +1,2 @@
-$(".likable_form_" + "<%= @likable.id %>").html("<%= escape_javascript(render partial: 'likes/like_form', locals: { likable: @likable }) %>")
-$(".likable_count_" + "<%= @likable.id %>").html("<%= @likable.likes.count %>")
+$(".likable_form_" + "<%= @likable.class.name %>_<%= @likable.id %>").html("<%= escape_javascript(render partial: 'likes/like_form', locals: { likable: @likable }) %>")
+$(".likable_count_" + "<%= @likable.class.name %>_<%= @likable.id %>").html("<%= @likable.likes.count %>")

--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -1,6 +1,6 @@
 - if user_signed_in?
   .text-center
-    = form_with model: @question do |f|
+    = form_with model: @question, local: true do |f|
       = render 'shared/error_messages', model: f.object
       .form-group
         = f.label :title

--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -1,6 +1,6 @@
 - if user_signed_in?
   .text-center
-    = form_with model: @question, local: true do |f|
+    = form_with model: question, local: true do |f|
       = render 'shared/error_messages', model: f.object
       .form-group
         = f.label :title
@@ -20,4 +20,7 @@
               .badge.badge-secondary.mr-1
                 = category.text
       .form-group
-        = f.submit '質問', class: 'btn btn-primary'
+        - if current_page?(action: 'new')
+          = f.submit '質問', class: 'btn btn-primary'
+        - elsif current_page?(action: 'edit')
+          = f.submit '編集内容を送信', class: 'btn btn-primary'

--- a/app/views/questions/edit.html.slim
+++ b/app/views/questions/edit.html.slim
@@ -1,17 +1,1 @@
-- if current_user == @question.user
-  = form_with model: @question, url: question_path(@question.id) do |f|
-    = render 'shared/error_messages', model: f.object
-    .form-group
-      = f.label :title
-      = f.text_field :title
-    .form-group
-      = f.label :content
-      = f.text_area :content
-    .form-group
-      = f.label :category, 'カテゴリ'
-      = f.collection_check_boxes(:category_ids, Category.all, :id, :name, include_hidden: false) do |category|
-        = category.label do
-          = category.check_box
-          .badge.badge-secondary
-            = category.text
-    = f.submit '編集内容を送信', class: 'btn btn-primary'
+= render partial: 'questions/form', locals: { question: @question }

--- a/app/views/questions/new.html.slim
+++ b/app/views/questions/new.html.slim
@@ -1,4 +1,4 @@
-= render partial: 'questions/form'
+= render partial: 'questions/form', locals: { question: @question }
 - unless user_signed_in?
   .text_center
     = link_to 'ログイン', new_user_session_path

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -37,11 +37,11 @@
     = render partial: 'comments/index', locals: { comments: @question.comments }
     / コメント、回答入力フォーム
     - if user_signed_in?
-      button data-toggle='collapse' data-target='#collapse_comment' aria-expanded='false' aria-controls='collapse_comment' 
+      button data-toggle='collapse' data-target='#collapse_comment_question' aria-expanded='false' aria-controls='collapse_comment' 
         p.bold_texts #{icon('far', 'comment')}コメントを投稿
       button.ml-5 data-toggle='collapse' data-target='#collapse_answer' aria-expanded='false' aria-controls='collapse_answer'
         p.bold_texts #{icon('far', 'paper-plane')} 回答
-      .collapse#collapse_comment
+      .collapse#collapse_comment_question
         hr
         = render partial: 'comments/form', locals: { commentable: @question, comment: current_user.comments.build }
       .collapse#collapse_answer

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,6 +1,16 @@
 ---
   ja:
     activerecord:
+      attributes:
+        question:
+          title: 'タイトル'
+          content: '内容'
+        answer:
+          content: '内容'
+        post:
+          content: '内容'
+        comment:
+          content: '内容'
       errors:
         messages:
           record_invalid: 'バリデーションに失敗しました: %{errors}'

--- a/db/migrate/20200328121605_change_data_type.rb
+++ b/db/migrate/20200328121605_change_data_type.rb
@@ -1,0 +1,5 @@
+class ChangeDataType < ActiveRecord::Migration[5.2]
+  def change
+    change_column :questions, :content, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_19_202703) do
+ActiveRecord::Schema.define(version: 2020_03_28_121605) do
 
   create_table "answers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "content"
@@ -83,7 +83,7 @@ ActiveRecord::Schema.define(version: 2020_03_19_202703) do
   end
 
   create_table "questions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "content"
+    t.text "content"
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/system/question/question_spec.rb
+++ b/spec/system/question/question_spec.rb
@@ -39,16 +39,46 @@ RSpec.describe "Questions", type: :system do
       end
     end
 
-    it 'titleが空白の場合、失敗すること' do
-      fill_in 'question[title]', with: ''
-      fill_in 'question[content]', with: 'content'
-      expect { click_button '質問' }.to change { taro.questions.count }.by(0)
-    end
+    describe '異常値' do
+      describe 'title' do
+        context '空白の場合' do
+          example '失敗し、エラーメッセージが表示されること' do
+            fill_in 'question[title]', with: ''
+            fill_in 'question[content]', with: 'content'
+            expect { click_button '質問' }.to change { taro.questions.count }.by(0)
+            expect(page).to have_content "タイトルを入力してください"
+          end
+        end
 
-    it 'contentが空白の場合、失敗すること' do
-      fill_in 'question[title]', with: 'title'
-      fill_in 'question[content]', with: ''
-      expect { click_button '質問' }.to change { taro.questions.count }.by(0)
+        context '文字数オーバーの場合' do
+          example '失敗し、エラーメッセージが表示されること' do
+            fill_in 'question[title]', with: 'a' * 51
+            fill_in 'question[content]', with: 'content'
+            expect { click_button '質問' }.to change { taro.questions.count }.by(0)
+            expect(page).to have_content "タイトルは50文字以内で入力してください"
+          end
+        end
+      end
+
+      describe 'content' do
+        context '空白の場合' do
+          example '失敗し、エラーメッセージが表示されること' do
+            fill_in 'question[title]', with: 'title'
+            fill_in 'question[content]', with: ''
+            expect { click_button '質問' }.to change { taro.questions.count }.by(0)
+            expect(page).to have_content "内容を入力してください"
+          end
+        end
+
+        context '文字数オーバーの場合' do
+          example '失敗し、エラーメッセージが表示されること' do
+            fill_in 'question[title]', with: 'title'
+            fill_in 'question[content]', with: 'a' * 1001
+            expect { click_button '質問' }.to change { taro.questions.count }.by(0)
+            expect(page).to have_content "内容は1000文字以内で入力してください"
+          end
+        end
+      end
     end
   end
 

--- a/spec/system/question/question_spec.rb
+++ b/spec/system/question/question_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe "Questions", type: :system do
-  let(:taro) { create(:user, name: 'taro') }
-  let(:jiro) { create(:user, name: 'jiro') }
+  let!(:taro) { create(:user, name: 'taro') }
+  let!(:jiro) { create(:user, name: 'jiro') }
   let!(:taro_q) { create(:question, user: taro) }
 
   describe '質問の投稿' do
@@ -54,9 +54,6 @@ RSpec.describe "Questions", type: :system do
 
   describe '質問の削除' do
     # 質問者 = 'taro'
-    let(:taro) { create(:user, name: 'taro') }
-    let(:jiro) { create(:user, name: 'jiro') }
-    let!(:taro_q) { create(:question, user: taro) }
 
     it '質問者は質問を削除できること' do
       login_as taro, scope: :user


### PR DESCRIPTION
#76 #5 

## 変更点

### 質問モデル
- answerとquestionのidが同じ時、片方にいいねすると両方いいねされてしまう問題対策
  - 原因: いいねボタンのclass名を`likable.id`で指定しているためidが同じ場合、ajaxでどちらもいいねされたように見えてしまう(実際には表示だけ)
  - 対策: class名に`likable.class.name`, `likable.id`を取り、一意性を担保して解決

- エラーメッセージ が表示されない問題
  - 原因: save失敗後、redirect_toでリダイレクトしていたため
  - 対策: renderで描画することで解決。renderとredirectの違いをちゃんと理解していなかったのが問題
また、flashとflash.nowの違いについてもようやく理解した。
flash => 次のアクション終了時まで
flash.now => 次のアクション開始時まで

### 回答、コメントモデル

- この二つのモデルはPOSTリクエストが別のコントローラ内から実行されるため、エラーメッセージ が消えてしまう。現状はtext_areaに`required: true`, `maxlength: `オプションをつける形で対応。
時間がある時にまたしっかり直したい

### 投稿モデル
ルーティングやページ設計自体に問題があったため、また別のブランチを切ってそちらで行う