### PR TITLE
Feature/test user

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,4 +8,8 @@ class ApplicationController < ActionController::Base
     # 編集時
     devise_parameter_sanitizer.permit(:account_update, keys: [:name, :profile_image, :profile, :bunri])
   end
+
+  def check_guest
+    redirect_to root_path, alert: 'ゲストユーザーは削除、変更できません' if current_user.guest?
+  end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
+  before_action :check_guest, only: [:destroy, :update]
+
   protected
 
   def after_sign_up_path_for(resource)

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -3,6 +3,12 @@
 class Users::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
 
+  def new_guest
+    user = User.guest
+    sign_in user
+    redirect_to root_path, notice: 'ゲストユーザーとしてログインしました'
+  end
+
   # GET /resource/sign_in
   # def new
   #   super

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -148,4 +148,11 @@ class User < ApplicationRecord
   def self.create_ranking(obj)
     User.find(obj.group(:user_id).order('count(user_id) desc').limit(10).pluck(:user_id))
   end
+
+  # ゲストユーザー周り
+  def self.guest
+    find_or_create_by!(email: 'guest@example.com', name: 'ゲストユーザー') do |user|
+      user.password = SecureRandom.urlsafe_base64
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,12 @@ class User < ApplicationRecord
   # mount_uploader
   mount_uploader :profile_image, ProfileImageUploader
 
+  enum role: {
+    normal: 0,
+    admin: 1,
+    guest: 2,
+  }
+
   enum bunri: {
     undecided: 0,
     bunkei: 1,
@@ -151,8 +157,9 @@ class User < ApplicationRecord
 
   # ゲストユーザー周り
   def self.guest
-    find_or_create_by!(email: 'guest@example.com', name: 'ゲストユーザー') do |user|
+    find_by(email: 'guest@guest.com') || find_or_create_by(name: 'ゲスト', role: :guest) do |user|
       user.password = SecureRandom.urlsafe_base64
+      user.email = "guest_#{Time.now.to_i}#{rand(100)}@example.com"
     end
   end
 end

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -24,6 +24,8 @@ nav.navbar.navbar-expand-lg.navbar-light
           = link_to icon('fas', 'sign-in-alt') + 'ログイン', new_user_session_path, class: 'nav-link'
         li.nav-item
           = link_to icon('fas', 'user-plus') + '登録', new_user_registration_path, class: 'nav-link'
+        li.nav-item
+          = link_to 'ゲストログイン', users_guest_sign_in_path, method: :post, class: 'nav-link'
   
   / 通知、ドロップダウンメニュー
   - if user_signed_in?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,10 @@ Rails.application.routes.draw do
     registrations: 'users/registrations',
   }
 
+  devise_scope :user do
+    post 'users/guest_sign_in', to: 'users/sessions#new_guest'
+  end
+
   resources :users, only: [:show], shallow: true do
     resources :stocks, only: [:index, :create, :destroy]
     resources :followees, only: [:index, :create, :destroy]

--- a/db/migrate/20200331101632_add_role_to_users.rb
+++ b/db/migrate/20200331101632_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :role, :integer, default: 0, limit: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_30_042916) do
+ActiveRecord::Schema.define(version: 2020_03_31_101632) do
 
   create_table "answers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "content"
@@ -134,6 +134,7 @@ ActiveRecord::Schema.define(version: 2020_03_30_042916) do
     t.string "profile_image"
     t.text "profile"
     t.integer "bunri", limit: 1, default: 0
+    t.integer "role", limit: 1, default: 0
     t.index ["bunri"], name: "index_users_on_bunri"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,6 +2,13 @@ require 'faker'
 
 Faker::Config.locale = :ja
 
+guest = User.create(
+  name: 'ゲスト',
+  email: 'guest@guest.com',
+  password: 'password',
+  role: :guest
+)
+
 hoge = User.create(
   name: "hogehoge",
   email: "hogehoge@hogehoge.com",

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     password { 'password' }
     profile { nil }
     bunri { 0 }
+    role { 0 }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -354,8 +354,18 @@ RSpec.describe User, type: :model do
 
   describe 'ゲストユーザー機能' do
     describe 'User.guest' do
-      example 'ゲストユーザーを返すこと' do
-        expect(User.guest).to eq User.find_by(email: 'guest@example.com')
+      context 'seeds.rbで定義したゲストユーザーが削除されてない場合' do
+        let!(:guest) { create(:user, email: 'guest@guest.com', role: :guest) }
+
+        example 'ゲストユーザーを返すこと' do
+          expect(User.guest).to eq guest
+        end
+      end
+
+      context 'ゲストユーザーが削除されている時' do
+        example 'ゲストユーザーを返すこと' do
+          expect(User.guest.guest?).to eq true
+        end
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -351,4 +351,12 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe 'ゲストユーザー機能' do
+    describe 'User.guest' do
+      example 'ゲストユーザーを返すこと' do
+        expect(User.guest).to eq User.find_by(email: 'guest@example.com')
+      end
+    end
+  end
 end

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe "Users::Registrations", type: :request do
+  let!(:guest) { create(:user, role: :guest) }
+
+  describe '#update' do
+    context 'ゲストユーザーとしてログインしている時' do
+      before { sign_in guest }
+
+      example 'ホーム画面へリダイレクトされること' do
+        put user_registration_path
+        expect(response).to redirect_to root_path
+      end
+    end
+  end
+
+  describe '#destroy' do
+    context 'ゲストユーザーとしてログインしている時' do
+      before { sign_in guest }
+
+      example 'ホーム画面へリダイレクトされること' do
+        delete user_registration_path
+        expect(response).to redirect_to root_path
+      end
+    end
+  end
+end

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "Users::Sessions", type: :request do
+  describe '#new_guest' do
+    example 'リダイレクトされること' do
+      post users_guest_sign_in_path
+      expect(response).to redirect_to root_path
+    end
+  end
+end

--- a/spec/system/users/users_sign_ins_spec.rb
+++ b/spec/system/users/users_sign_ins_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe "Users::SignIns", type: :system do
+  let!(:user) { create(:user) }
+
+  before do
+    visit new_user_session_path
+    fill_in 'メールアドレス', with: user.email
+    fill_in 'パスワード', with: 'password'
+  end
+
+  describe '正常値' do
+    example '正常にサインインできること' do
+      click_button 'ログイン'
+      expect(page).to have_content 'ログインしました。'
+    end
+  end
+
+  describe '組み合わせが正しくない場合' do
+    example 'ログインできないこと' do
+      fill_in 'メールアドレス', with: 'failure@failure.com'
+      click_button 'ログイン'
+      expect(page).to have_content 'メールアドレスまたはパスワードが違います。'
+    end
+  end
+
+  describe 'ゲストユーザーログイン' do
+    example 'ゲストユーザーとしてログインできること' do
+      click_link 'ゲストログイン'
+      expect(page).to have_content 'ゲストユーザーとしてログインしました'
+    end
+  end
+end


### PR DESCRIPTION
#96 
ゲストユーザーログイン機能実装

## 仕様

- ヘッダー内のゲストログインリンクをクリックすると、ゲストユーザーとしてログインできる
- ゲストユーザーはユーザー情報の編集、退会が行えない

## 実装の過程

https://qiita.com/take18k_tech/items/35f9b5883f5be4c6e104
最初はこちらの記事を参考にメソッドでテストユーザーを作成する形で実装していたが、後々admin機能をつけることを考えて、 Userモデルにroleカラムを追加してadmin, normal, guestを判定する形にした。

これならゲストユーザーの判定もenumのメソッドで行えるし、事前に作っておいたゲストユーザーにデモデータを持たせることができる

無駄なコミットになったが、一応以前の実装の過程も残しておく