### PR TITLE
Reflect feedback/ui ux

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -122,6 +122,47 @@ button {
   padding: 0;
 }
 
+@mixin new_button() {
+  width: 60px;
+  height: 60px;
+  display: flex;
+  background-color: #007afc;
+  border: white;
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+@mixin new_button_text() {
+  text-align: center;
+  vertical-align: middle;
+  margin-top: 10px;
+  color: white;
+  font-weight: bold;
+  font-size: 24px;
+}
+
+.question_button {
+  position: fixed;
+  right:50px;
+  bottom:10%;
+  @include new_button();
+  p {
+    @include new_button_text();
+  }
+}
+
+.post_button {
+  position: fixed;
+  right:50px;
+  bottom:18%;
+  @include new_button();
+  p {
+    @include new_button_text();
+  }
+}
+
 // 質問一覧ページのスタイリング
 .question_index_container {
   @include basic_container();

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -18,10 +18,10 @@ class PostsController < ApplicationController
     @post = current_user.posts.new(post_params)
     @post.set_taggable
     if @post.save
-      flash[:success] = '投稿に成功しました'
+      flash[:success] = 'つぶやきました'
       redirect_to posts_path
     else
-      flash.now[:danger] = '投稿に失敗しました'
+      flash.now[:danger] = 'つぶやきに失敗しました'
       render action: :new
     end
   end

--- a/app/views/category/_follow_button.html.slim
+++ b/app/views/category/_follow_button.html.slim
@@ -5,7 +5,7 @@
         / unfollow
         = form_with url: unfollow_category_path, remote: true, method: :delete do |f|
           = f.hidden_field :category_id, value: category.id
-          = f.submit 'フォロー解除', class: 'btn btn-primary'
+          = f.submit 'フォロー解除', class: 'btn btn-success'
       - else
         / follow
         = form_with url: follow_category_path, remote: true, method: :post do |f|

--- a/app/views/category/categories/show.html.slim
+++ b/app/views/category/categories/show.html.slim
@@ -8,7 +8,7 @@ ul.nav.nav-tabs.justify-content-center.my-4
   li.nav-item
     a.nav-link.bold_texts.active data-toggle="tab" href="#category_questions" #{@category.name}の質問
   li.nav-item
-    a.nav-link.bold_texts data-toggle="tab" href="#category_posts" #{@category.name}の投稿
+    a.nav-link.bold_texts data-toggle="tab" href="#category_posts" #{@category.name}のつぶやき
   li.nav-item
     a.nav-link.bold_texts data-toggle="tab" href="#category_users" #{@category.name}のフォロワー
 / タブの表示部分

--- a/app/views/home/home.html.slim
+++ b/app/views/home/home.html.slim
@@ -9,10 +9,10 @@
     - if user_signed_in?
       .text-center
         = link_to '質問する', new_question_path, class: 'btn btn-success mr-4'
-        = link_to '投稿する', new_post_path, class: 'btn btn-success'
+        = link_to 'つぶやく', new_post_path, class: 'btn btn-success'
         hr
         = link_to '質問一覧', questions_path, class: 'btn btn-success mr-4'
-        = link_to '投稿一覧', posts_path, class: 'btn btn-success'
+        = link_to 'つぶやき一覧', posts_path, class: 'btn btn-success'
     - else
       .text-center
         = link_to 'ゲストユーザーとしてログイン', users_guest_sign_in_path, method: :post, class: 'btn btn-success'

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -14,12 +14,7 @@ nav.navbar.navbar-expand-lg.navbar-light
         = link_to '投稿一覧', posts_path, class: 'nav-link'
       li.nav-item
         = link_to 'カテゴリー', category_categories_path, class: 'nav-link'
-      - if user_signed_in?
-        li.nav-item
-            = link_to '質問する', new_question_path, class: 'nav-link'
-        li.nav-item
-            = link_to '投稿する', new_post_path, class: 'nav-link'
-      - else
+      - unless user_signed_in?
         ul.navbar-nav.mr-auto
           li.nav-item.dropdown
             a#navbarDropdown.nav-link.dropdown-toggle aria-expanded="false" aria-haspopup="true" data-toggle="dropdown" href="#" role="button" 

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -11,7 +11,7 @@ nav.navbar.navbar-expand-lg.navbar-light
       li.nav-item
         = link_to '質問一覧', questions_path, class: 'nav-link'
       li.nav-item
-        = link_to '投稿一覧', posts_path, class: 'nav-link'
+        = link_to 'つぶやき一覧', posts_path, class: 'nav-link'
       li.nav-item
         = link_to 'カテゴリー', category_categories_path, class: 'nav-link'
       - unless user_signed_in?

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -20,12 +20,14 @@ nav.navbar.navbar-expand-lg.navbar-light
         li.nav-item
             = link_to '投稿する', new_post_path, class: 'nav-link'
       - else
-        li.nav-item
-          = link_to icon('fas', 'sign-in-alt') + 'ログイン', new_user_session_path, class: 'nav-link'
-        li.nav-item
-          = link_to icon('fas', 'user-plus') + '登録', new_user_registration_path, class: 'nav-link'
-        li.nav-item
-          = link_to 'ゲストログイン', users_guest_sign_in_path, method: :post, class: 'nav-link'
+        ul.navbar-nav.mr-auto
+          li.nav-item.dropdown
+            a#navbarDropdown.nav-link.dropdown-toggle aria-expanded="false" aria-haspopup="true" data-toggle="dropdown" href="#" role="button" 
+              | #{icon('fas', 'sign-in-alt')}
+            .dropdown-menu aria-labelledby="navbarDropdown" 
+              = link_to 'ゲストログイン', users_guest_sign_in_path, method: :post, class: 'dropdown-item'
+              = link_to icon('fas', 'sign-in-alt') + ' '+ 'ログイン', new_user_session_path, class: 'dropdown-item'
+              = link_to icon('fas', 'user-plus') + ' ' + '登録', new_user_registration_path, class: 'dropdown-item'
   
   / 通知、ドロップダウンメニュー
   - if user_signed_in?

--- a/app/views/layouts/_new_button.html.slim
+++ b/app/views/layouts/_new_button.html.slim
@@ -1,0 +1,9 @@
+- if user_signed_in?
+  = link_to new_question_path do
+    .question_button
+      .question_button_text
+        p +#{icon('fab', 'quora')}
+  = link_to new_post_path do
+    .post_button
+      .post_button_text
+        p +#{icon('far', 'comment-dots')}

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -11,5 +11,6 @@ html
     main
       = render 'shared/flash'
       = yield
+      = render partial: 'layouts/new_button'
     footer
       = render 'layouts/footer'

--- a/app/views/notifications/_notification.html.slim
+++ b/app/views/notifications/_notification.html.slim
@@ -24,6 +24,6 @@ div class=(notification.checked ? '' : 'new_notification')
         = link_to '質問の回答', question_path(notification.comment.commentable.id)
         | にコメントしました
       - when 'Post' then
-        = link_to '投稿', post_path(notification.comment.commentable.id)
+        = link_to 'つぶやき', post_path(notification.comment.commentable.id)
         | にコメントしました
     hr

--- a/app/views/posts/_form.html.slim
+++ b/app/views/posts/_form.html.slim
@@ -1,7 +1,7 @@
 = form_with model: post, local: true do |f|
   = render 'shared/error_messages', model: f.object
   .form-group
-    = f.label :content, '投稿内容'
+    = f.label :content, '内容'
     br
     = f.text_area :content, class: 'large_text_area', placeholder: '内容を入力(1000)文字以内'
   .form-group
@@ -14,7 +14,7 @@
           .badge.badge-secondary.mr-1
             = category.text
   - if current_page?(action: 'new') || current_page?(action: 'index')
-    = f.submit '投稿する', class: 'btn btn-primary'
+    = f.submit 'つぶやく', class: 'btn btn-primary'
   - elsif current_page?(action: 'edit')
     = f.submit '編集', class: 'btn btn-primary'
     

--- a/app/views/posts/index.html.slim
+++ b/app/views/posts/index.html.slim
@@ -1,5 +1,5 @@
-- provide(:title, '投稿一覧')
-h1.text-center.font-weight-bold.py-3 投稿一覧
+- provide(:title, 'つぶやき')
+h1.text-center.font-weight-bold.py-3 つぶやき一覧
 - unless @posts.blank?
   hr
   .post_container

--- a/app/views/posts/new.html.slim
+++ b/app/views/posts/new.html.slim
@@ -1,3 +1,3 @@
-- provide(:title, '投稿')
+- provide(:title, 'つぶやき')
 .text-center
   = render partial: 'posts/form', locals: { post: @post }

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -1,4 +1,4 @@
-- provide(:title, "#{@post.user.name}さんの投稿")
+- provide(:title, "#{@post.user.name}さんのつぶやき")
 .post_container
   = render partial: 'posts/post', locals: { post: @post }
   .text-center

--- a/app/views/searches/index.html.slim
+++ b/app/views/searches/index.html.slim
@@ -1,5 +1,5 @@
-- provide(:title, '検索')
-h2.text-center.my-3 検索
+- provide(:title, '質問検索')
+h2.text-center.font-weight-bold.py-3 質問を検索
 .my-auto
   = search_form_for @search_questions, url: searches_path do |f|
     .text-center

--- a/app/views/shared/_follow_button.html.slim
+++ b/app/views/shared/_follow_button.html.slim
@@ -3,7 +3,7 @@
       -if current_user.following?(user)
         = form_with url: followee_path(user.id), remote: true, method: :delete do |f|
           = f.hidden_field :user_id, value: user.id
-          = f.submit 'フォロー解除', class: 'btn btn-primary'
+          = f.submit 'フォロー解除', class: 'btn btn-success'
       -else
         = form_with url: user_followees_path(user_id: user.id), remote: true, method: :post do |f|
           = f.submit 'フォローする', class: 'btn btn-primary'

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -47,7 +47,7 @@
         li.nav-item
           a.nav-link.bold_texts data-toggle="tab" href="#user_answers" 回答した質問
         li.nav-item
-          a.nav-link.bold_texts data-toggle="tab" href="#user_posts" 投稿
+          a.nav-link.bold_texts data-toggle="tab" href="#user_posts" つぶやき
       / タブの表示部分
       .tab-content.text-center
         #user_questions.tab-pane.active

--- a/spec/system/notifications_spec.rb
+++ b/spec/system/notifications_spec.rb
@@ -181,8 +181,8 @@ RSpec.describe "Notifications", type: :system do
 
       describe 'commentable => post' do
         include_examples 'コメント通知のテスト' do
-          let(:first_notification_text) { "#{comment.user.name}さんが投稿にコメントしました" }
-          let(:second_notification_text) { "#{other_comment.user.name}さんが投稿にコメントしました" }
+          let(:first_notification_text) { "#{comment.user.name}さんがつぶやきにコメントしました" }
+          let(:second_notification_text) { "#{other_comment.user.name}さんがつぶやきにコメントしました" }
           let!(:commentable) { create(:post) }
         end
       end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Posts", type: :system do
 
       example '正常に投稿できること' do
         check category.name
-        expect { click_button '投稿する' }.to change { user.posts.count }.by(1)
+        expect { click_button 'つぶやく' }.to change { user.posts.count }.by(1)
         within(".post_#{Post.last.id}") do
           expect(page).to have_content Post.last.content
           expect(page).to have_content category.name
@@ -24,14 +24,14 @@ RSpec.describe "Posts", type: :system do
       end
 
       example 'タグなしでも投稿できること' do
-        expect { click_button '投稿する' }.to change { user.posts.count }.by(1)
+        expect { click_button 'つぶやく' }.to change { user.posts.count }.by(1)
       end
     end
 
     context '異常値' do
       context '空白の場合' do
         example '投稿できず、エラーメッセージが表示されること' do
-          expect { click_button '投稿する' }.to change { user.posts.count }.by(0)
+          expect { click_button 'つぶやく' }.to change { user.posts.count }.by(0)
           expect(page).to have_content '内容を入力してください'
         end
       end
@@ -39,7 +39,7 @@ RSpec.describe "Posts", type: :system do
       context '文字数オーバーの場合' do
         example '投稿できず、エラーメッセージが表示されること' do
           fill_in 'post[content]', with: 'a' * 1001
-          expect { click_button '投稿する' }.to change { user.posts.count }.by(0)
+          expect { click_button 'つぶやく' }.to change { user.posts.count }.by(0)
           expect(page).to have_content "内容は1000文字以内で入力してください"
         end
       end


### PR DESCRIPTION
#113 
UI/UX部分の対応

## 変更点

- フォローボタンの色をフォロー前後で変更
https://github.com/YutoKashiwagi/Ukarimi/pull/118/commits/624bb58395ab3592d5a1982d3e4f27a083165e5a

- ユーザー登録リンクをプルダウンを使ってまとめる
https://github.com/YutoKashiwagi/Ukarimi/pull/118/commits/2f4303db47f1b8c1f3dd261ba12c80c17482b774

- 新規質問、投稿リンクを固定レイアウトに変更
https://github.com/YutoKashiwagi/Ukarimi/pull/118/commits/cb2461d3764daa40eaa4852ebe812dd41860af2d
https://github.com/YutoKashiwagi/Ukarimi/pull/118/commits/b8759bf529af3e0548fc6b48f08b7a073504943a

- 質問を検索と明示
https://github.com/YutoKashiwagi/Ukarimi/pull/118/commits/b69093667c1268fba356eebf82d2237cab1b0dae

- 「投稿」を「つぶやき」に名称変更
https://github.com/YutoKashiwagi/Ukarimi/pull/118/commits/e04b2d764080d3b9813f52f2597191a422eaa744
