### PR TITLE
Feature/friendly forwarding

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :store_user_location!, if: :storable_location?
 
   def configure_permitted_parameters
     # 新規登録時
@@ -9,7 +10,26 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:account_update, keys: [:name, :profile_image, :profile, :bunri])
   end
 
+  private
+
   def check_guest
-    redirect_to root_path, alert: 'ゲストユーザーは削除、変更できません' if current_user.guest?
+    if current_user.guest?
+      flash[:danger] = 'ゲストユーザーは削除、変更できません'
+      redirect_back(fallback_location: root_path)
+    end
+  end
+
+  def storable_location?
+    request.get? && is_navigational_format? && !devise_controller? && !request.xhr?
+  end
+
+  def store_user_location!
+    # https://github.com/heartcombo/devise/blob/079ed3b6f8b671acde2dd630d28d21adb010fb3a/lib/devise/controllers/store_location.rb#L34
+    store_location_for(:user, request.fullpath)
+  end
+
+  def after_sign_in_path_for(resource_or_scope)
+    # https://github.com/heartcombo/devise/blob/079ed3b6f8b671acde2dd630d28d21adb010fb3a/lib/devise/controllers/store_location.rb#L16
+    stored_location_for(resource_or_scope) || super
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -2,10 +2,4 @@
 
 class Users::RegistrationsController < Devise::RegistrationsController
   before_action :check_guest, only: [:destroy, :update]
-
-  protected
-
-  def after_sign_up_path_for(resource)
-    user_path(current_user)
-  end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -6,7 +6,7 @@ class Users::SessionsController < Devise::SessionsController
   def new_guest
     user = User.guest
     sign_in user
-    redirect_to root_path, notice: 'ゲストユーザーとしてログインしました'
+    redirect_to stored_location_for(:user) || root_path, notice: 'ゲストユーザーとしてログインしました'
   end
 
   # GET /resource/sign_in

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -2,9 +2,15 @@ require 'rails_helper'
 
 RSpec.describe "Users::Sessions", type: :request do
   describe '#new_guest' do
-    example 'リダイレクトされること' do
-      post users_guest_sign_in_path
-      expect(response).to redirect_to root_path
+    context 'session[:user_return_to]が存在しているとき' do
+      before do
+        get questions_path
+        post users_guest_sign_in_path
+      end
+
+      example 'フレンドリーフォワーディングされること' do
+        expect(response).to redirect_to questions_path
+      end
     end
   end
 end

--- a/spec/system/users/sign_ups_spec.rb
+++ b/spec/system/users/sign_ups_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "SignUps", type: :system do
 
   example '正常にサインアップできること' do
     click_button 'アカウント登録'
-    expect(page).to have_content 'foobar'
+    expect(page).to have_content 'アカウント登録が完了しました'
   end
 
   describe '異常値' do


### PR DESCRIPTION
フレンドリーフォワーディング実装

## 仕様
- ログイン、サインアップ時に事前に見ていたページにリダイレクトされる
- ゲストログイン時も同様

## その他変更点

- ゲストユーザーがプロフィールを編集したとき、編集ページにリダイレクトされるように変更

## 参考
https://blog.bakunyo.com/2016/12/30/devise-friendly-forwarding/
https://github.com/heartcombo/devise/wiki/How-To:-Redirect-back-to-current-page-after-sign-in,-sign-out,-sign-up,-update